### PR TITLE
update curly rule

### DIFF
--- a/rules/common.js
+++ b/rules/common.js
@@ -13,6 +13,8 @@ module.exports = {
     'exports': 'always-multiline',
     'functions': 'ignore',
   }],
+  // this prevents `if` clauses from being on-liners without curly braces
+  'curly': ['error', 'all'],
   // 150 is an arbitrary but reasonable limit
   'max-len': ['error', 150, 4],
   // this will allow unary operators in for loops only


### PR DESCRIPTION
this rule change prevents people from writing code like 

```js
let foo;
if (foo) bar = 'baz';
else bar = 'bat';
```


