### PR TITLE
Update no-restricted-syntax

### DIFF
--- a/rules/common.js
+++ b/rules/common.js
@@ -20,7 +20,29 @@ module.exports = {
   // this will allow unary operators in for loops only
   'no-plusplus': ['error', { 'allowForLoopAfterthoughts': true }],
   // this allows us to use `for...of` which is occasionally useful
-  'no-restricted-syntax': 'off',
+  'no-restricted-syntax': [
+    'error',
+    {
+      selector: 'ForInStatement',
+      message: 'for..in loops iterate over the entire prototype chain, which is virtually never what you want. Use Object.{keys,values,entries}, and iterate over the resulting array.',
+    },
+    {
+      selector: 'LabeledStatement',
+      message: 'Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand.',
+    },
+    {
+      selector: 'WithStatement',
+      message: '`with` is disallowed in strict mode because it makes code impossible to predict and optimize.',
+    },
+    {
+      selector: 'MethodDefinition[kind='set']',
+      message: 'Property setters are not allowed',
+    },
+    {
+      selector: 'MethodDefinition[kind='get']',
+      message: 'Property getters are not allowed',
+    },
+  ],
   // we can consider a more nuanced approach to this rule since
   // it's very configurable but disabled for now
   'object-curly-newline': 'off',


### PR DESCRIPTION
we were disabling this rule because we wanted to allow the use of `for...of` (we typically include the regenerator runtime in all our code); this had the consequence of suppressing errors on some rules we probably do want. 

instead, let's copypasta from the airbnb config but just remove the `for...of` restriction.

additionally we'll add errors for using getters & setters.